### PR TITLE
Deploy tinsey inside of filbert with git submodules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ ARG node_env
 ARG google_client_id
 ENV NODE_ENV=$node_env
 ENV GOOGLE_API_FILBERT_CLIENT_ID=$google_client_id
-ENV PORT=3002
 
 # NOTE: install of both devDependencies & dependencies required
 RUN yarn install --production=false; \
@@ -23,5 +22,6 @@ RUN mkdir /usr/local/logs
 
 # filbert sapper 3000
 # filbert API 3001
+ENV PORT=3002
 EXPOSE 3002
 CMD ["yarn", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:14
+
+WORKDIR /tinsey/
+COPY . .
+
+# "build time" ENVs must be set in Dockerfile via ARGs passed from docker-compose... fun
+ARG node_env
+ARG google_client_id
+ENV NODE_ENV=$node_env
+ENV GOOGLE_API_FILBERT_CLIENT_ID=$google_client_id
+
+# NOTE: install of both devDependencies & dependencies required
+RUN yarn install --production=false; \
+  yarn sapper-build;
+
+# multi-staged builds save space!
+FROM node:14-slim
+
+WORKDIR /usr/local/tinsey/
+COPY --from=0 /tinsey/ /usr/local/tinsey/
+RUN mkdir /usr/local/logs
+
+EXPOSE 3000
+CMD ["yarn", "sapper-start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,11 @@ ARG node_env
 ARG google_client_id
 ENV NODE_ENV=$node_env
 ENV GOOGLE_API_FILBERT_CLIENT_ID=$google_client_id
+ENV PORT=3002
 
 # NOTE: install of both devDependencies & dependencies required
 RUN yarn install --production=false; \
-  yarn sapper-build;
+  yarn build;
 
 # multi-staged builds save space!
 FROM node:14-slim
@@ -20,5 +21,7 @@ WORKDIR /usr/local/tinsey/
 COPY --from=0 /tinsey/ /usr/local/tinsey/
 RUN mkdir /usr/local/logs
 
-EXPOSE 3000
-CMD ["yarn", "sapper-start"]
+# filbert sapper 3000
+# filbert API 3001
+EXPOSE 3002
+CMD ["yarn", "start"]

--- a/src/routes/_database.js
+++ b/src/routes/_database.js
@@ -1,7 +1,7 @@
 const knex = require('knex');
 
 const mysqlConnectionConfig = {
-  host: 'localhost',
+  host: process.env.NODE_ENV === 'production' ? 'db' : 'localhost', // docker-compose.yml service name
   port: 3306,
   user: 'root',
   password: process.env.MYSQL_ROOT_PASSWORD,

--- a/src/routes/_database.js
+++ b/src/routes/_database.js
@@ -1,7 +1,7 @@
 const knex = require('knex');
 
 const mysqlConnectionConfig = {
-  host: process.env.NODE_ENV === 'production' ? 'db' : 'localhost', // docker-compose.yml service name
+  host: 'localhost',
   port: 3306,
   user: 'root',
   password: process.env.MYSQL_ROOT_PASSWORD,


### PR DESCRIPTION
filbert includes tinsey as a git submodule.  This is to take advantage of the load balancer, letsencrypt and MySQL database that filbert already has setup.